### PR TITLE
Fix viewmodel flashlight.

### DIFF
--- a/sp/src/game/client/c_baseplayer.cpp
+++ b/sp/src/game/client/c_baseplayer.cpp
@@ -1230,28 +1230,31 @@ void C_BasePlayer::UpdateFlashlight()
 			m_pFlashlight->TurnOn();
 		}
 
+		Vector vecOrigin = EyePosition();
 		Vector vecForward, vecRight, vecUp;
 		QAngle angOrigin;
 
 		if (GetViewModel())
 		{
-			int iMuzzle = LookupAttachment("muzzle");
+			int iMuzzle = GetViewModel()->LookupAttachment("muzzle");
 
-			if (iMuzzle != -1)
+			if (iMuzzle > 0)
 			{
-				GetViewModel()->GetAttachment(iMuzzle, EyePosition(), angOrigin);
+				GetViewModel()->GetAttachment(iMuzzle, vecOrigin, angOrigin);
 			
-				::FormatViewModelAttachment(EyePosition(), true);
+				::FormatViewModelAttachment(vecOrigin, true);
 				AngleVectors(angOrigin, &vecForward, &vecRight, &vecUp);
 			
-				EyePosition() = vecForward * -35.0f + EyePosition();
+				vecOrigin += vecForward * -35.0f;
 			}
+			else
+				EyeVectors( &vecForward, &vecRight, &vecUp );
 		}
-
-		EyeVectors( &vecForward, &vecRight, &vecUp );
+		else
+			EyeVectors( &vecForward, &vecRight, &vecUp );
 
 		// Update the light with the new position and direction.		
-		m_pFlashlight->UpdateLight( EyePosition(), vecForward, vecRight, vecUp, FLASHLIGHT_DISTANCE );
+		m_pFlashlight->UpdateLight( vecOrigin, vecForward, vecRight, vecUp, FLASHLIGHT_DISTANCE );
 	}
 	else if (m_pFlashlight)
 	{


### PR DESCRIPTION
Changes:

1. Changed LookupAttachment() to GetViewModel()->LookupAttachment()
2. Added a variable vecOrigin to use instead of EyePosition(), which returns an instance of the eye position.
3. Changed iMuzzle != -1 to iMuzzle > 0

Notes:
- LookupAttachment returns 0 if no attachment can be found
- GetAttachment() will return the entity's absolute position and angles if the attachment is <= 0

Tests made:

1. Valid muzzle attachment (Any weapon that has a "muzzle" attachment)
2. No muzzle attachment (Crowbar/Knife)
3. No viewmodel (In console, type `ent_remove viewmodel`)