### PR TITLE
Fix John model.

### DIFF
--- a/sp/src/game/server/1187/npc_john.cpp
+++ b/sp/src/game/server/1187/npc_john.cpp
@@ -123,23 +123,11 @@ END_DATADESC()
 
 void CNPC_John::SelectModel()
 {
-	// HBN reporter use John NPC as entity support.
-	// Every npc_john entity whose name matches 'reporter'
-	// will have their model changed for a different model.
-	if (FStrEq(STRING(GetEntityName()), "reporter"))
+	char *szModel = (char *)STRING(GetModelName());
+	if (!szModel || !*szModel)
 	{
-		SetModelName(AllocPooledString("models/humans/group01/female_03.mdl"));
+		SetModelName(AllocPooledString(JOHH_MODEL));
 	}
-
-	// For the Rogue Train bonus map, the John NPC
-	// is used for Markus.
-
-	if (FStrEq(STRING(GetEntityName()), "markus"))
-	{
-		SetModelName(AllocPooledString("models/monk.mdl"));
-	}
-
-	SetModelName(AllocPooledString(JOHH_MODEL));
 }
 
 void CNPC_John::Precache(void)


### PR DESCRIPTION
### Changes

Sets the model that was provided by the map maker. All npc_john occurences define which model to use.

### Notes

- Map 1187d7 includes an npc_john with `models/humans/group01/male_09.mdl` which was unhandled in code.
- The first two SetModelName() were overriden by the last SetModelName() which was setting the default John model.

### Additional information

The following strings don't appear in the original server.dll :

```text
models/humans/group01/female_03.mdl
reporter
markus
```

`models/monk.mdl` appears but is likely due to npc_monk.

### Tests made

All maps loaded via console, Crash course, New game, Bonus Maps :

```text
1187d1.bsp
1187d10.bsp
1187d2.bsp
1187d3.bsp
1187d4.bsp
1187d5.bsp
1187d6.bsp
1187d7.bsp
1187d8.bsp
1187d9.bsp
1187_crashcourse.bsp
1187_farm_bonus.bsp
1187_roguetrain_bonus.bsp
```

In sdk_vehicles.bsp :

`npc_create npc_john` -> spawns a valid John NPC with Male_04.mdl, as expected.
