### PR TITLE
Fix player's view jittering when view realism is enabled.

### DIFF
--- a/sp/src/game/client/c_baseplayer.cpp
+++ b/sp/src/game/client/c_baseplayer.cpp
@@ -1400,6 +1400,13 @@ void C_BasePlayer::CreateWaterEffects( void )
 //-----------------------------------------------------------------------------
 void C_BasePlayer::OverrideView( CViewSetup *pSetup )
 {
+}
+
+//-----------------------------------------------------------------------------
+// 1187: Calculates view realism.
+//-----------------------------------------------------------------------------
+void C_BasePlayer::CalcViewRealism( CViewSetup *pSetup )
+{
 	if (!cl_viewrealism.GetInt() || camhack_control.GetInt())
 	{
 		return;

--- a/sp/src/game/client/c_baseplayer.cpp
+++ b/sp/src/game/client/c_baseplayer.cpp
@@ -1409,7 +1409,7 @@ void C_BasePlayer::OverrideView( CViewSetup *pSetup )
 	{
 		int iPlayerEyes = GetViewModel(0)->LookupAttachment("1187eyefix");
 
-		if (iPlayerEyes)
+		if (iPlayerEyes > 0)
 		{
 			GetViewModel(0)->GetAttachment(iPlayerEyes, Vector(0,0,0), pSetup->angles);
 		}

--- a/sp/src/game/client/c_baseplayer.h
+++ b/sp/src/game/client/c_baseplayer.h
@@ -288,6 +288,9 @@ public:
 	// Called when not in tactical mode. Allows view to be overriden for things like driving a tank.
 	virtual void				OverrideView( CViewSetup *pSetup );
 
+	// 1187: Calculates view realism.
+	virtual void				CalcViewRealism( CViewSetup *pSetup );
+
 	// returns the player name
 	const char *				GetPlayerName();
 	virtual const Vector		GetPlayerMins( void ) const; // uses local player

--- a/sp/src/game/client/view.cpp
+++ b/sp/src/game/client/view.cpp
@@ -780,6 +780,12 @@ void CViewRender::SetUpViews()
 		pPlayer->CalcViewModelView ( ViewModelOrigin, ViewModelAngles );
 	}
 
+	if ( pPlayer )
+	{
+		// 1187: Must be called after CalcViewModelView since we depend on viewmodel's angles.
+		pPlayer->CalcViewRealism( &view );
+	}
+
 	// Disable spatial partition access
 	partition->SuppressLists( PARTITION_ALL_CLIENT_EDICTS, true );
 


### PR DESCRIPTION
The player's view was jittering when `cl_viewrealism` is enabled. After moving the code to a separate function and calling it after CalcViewModelView, the issue no longer happens. 

It's likely due to view realism's code getting the `1187eyefix` attachment before the viewmodel's angles are updated in CalcViewModelView, so it uses the wrong angles. At least, I haven't found anything else that could be the cause.

## Changes

1. Changed iPlayerEyes to iPlayerEyes > 0
2. Moved view realism code to a separate function and call it after CalcViewModelView

## Notes

- Vector(0,0,0) in `GetViewModel(0)->GetAttachment()` is ok in this case since it's not used anywhere else.

## Tests made

1. Throw a grenade
4. With the following weapons:

```text
weapon_357
weapon_colt
weapon_crowbar
weapon_dualpistol
weapon_healthpack
weapon_kar98
weapon_knife
weapon_m16
weapon_m4
weapon_pistol
weapon_rpg
weapon_shotgun
weapon_smg1
```
