### PR TITLE
Fix duck hull, duck view offset, time to duck.

### DIFF
--- a/src/game/shared/gamemovement.cpp
+++ b/src/game/shared/gamemovement.cpp
@@ -4320,12 +4320,15 @@ bool CGameMovement::CanUnDuckJump( trace_t &trace )
 {
 	// Trace down to the stand position and see if we can stand.
 	Vector vecEnd( mv->GetAbsOrigin() );
-	vecEnd.z -= 36.0f;						// This will have to change if bounding hull change!
+	Vector hullSizeNormal = VEC_HULL_MAX_SCALED(player) - VEC_HULL_MIN_SCALED(player);
+	Vector hullSizeCrouch = VEC_DUCK_HULL_MAX_SCALED(player) - VEC_DUCK_HULL_MIN_SCALED(player);
+	Vector viewDelta = hullSizeNormal - hullSizeCrouch;
+	vecEnd.z -= viewDelta.z;
 	TracePlayerBBox( mv->GetAbsOrigin(), vecEnd, PlayerSolidMask(), COLLISION_GROUP_PLAYER_MOVEMENT, trace );
 	if ( trace.fraction < 1.0f )
 	{
 		// Find the endpoint.
-		vecEnd.z = mv->GetAbsOrigin().z + ( -36.0f * trace.fraction );
+		vecEnd.z = mv->GetAbsOrigin().z + ( -viewDelta.z * trace.fraction );
 
 		// Test a normal hull.
 		trace_t traceUp;

--- a/src/game/shared/gamerules.cpp
+++ b/src/game/shared/gamerules.cpp
@@ -49,8 +49,8 @@ static CViewVectors g_DefaultViewVectors(
 	Vector( 16,  16,  72 ),		//VEC_HULL_MAX (m_vHullMax)
 													
 	Vector(-16, -16, 0 ),		//VEC_DUCK_HULL_MIN (m_vDuckHullMin)
-	Vector( 16,  16,  36 ),		//VEC_DUCK_HULL_MAX	(m_vDuckHullMax)
-	Vector( 0, 0, 28 ),			//VEC_DUCK_VIEW		(m_vDuckView)
+	Vector( 16,  16, 48 ),		//VEC_DUCK_HULL_MAX	(m_vDuckHullMax)
+	Vector( 0, 0, 42 ),			//VEC_DUCK_VIEW		(m_vDuckView)
 													
 	Vector(-10, -10, -10 ),		//VEC_OBS_HULL_MIN	(m_vObsHullMin)
 	Vector( 10,  10,  10 ),		//VEC_OBS_HULL_MAX	(m_vObsHullMax)

--- a/src/game/shared/shareddefs.h
+++ b/src/game/shared/shareddefs.h
@@ -106,8 +106,8 @@ public:
 	#define TIME_TO_DUCK		0.2
 	#define TIME_TO_DUCK_MS		200.0f
 #else
-	#define TIME_TO_DUCK		0.4
-	#define TIME_TO_DUCK_MS		400.0f
+	#define TIME_TO_DUCK		0.2
+	#define TIME_TO_DUCK_MS		200.0f
 #endif 
 #define TIME_TO_UNDUCK		0.2
 #define TIME_TO_UNDUCK_MS	200.0f


### PR DESCRIPTION
This should fix:
- Player hull while ducked
- Player view offset while ducked
- Time to duck

The behavior was compared against the original mod and it looks ok. 

Tests maps are provided:

[test_playerhull.zip](https://github.com/user-attachments/files/15859258/test_playerhull.zip)

[test_viewheight.zip](https://github.com/user-attachments/files/15859259/test_viewheight.zip)

## Changes

- Makes ducking faster
- Sets correct duck view offset

## Notes

### gamemovement.cpp

Changes in `gamemovement.cpp` had to be made since some parts in the code assume the view delta is still 36. I checked the following tutorial as a starting point. 

https://developer.valvesoftware.com/wiki/Player_Entity#Collision_Hull

The tutorial changes the code to use normal/duck view offset for the view delta as opposed to the regular code which uses min/max hull values. As of now, I only replaced the `36.0f` with the min/max hull calculation (as seen in other parts in `gamemovement.cpp`) and it seems to work. 

For the proposed `AIRDUCKORIGINOFFSET`, I'm not convinced that using view offset values instead of min/max hull values is a good thing to do so I'll leave it as is for now. If any issue arise, we can revisit it.

### Viewmodel

If you equip with any weapon and look up while in one of the holes in map `test_playerhull.bsp`, you'll notice the viewmodel can clip through the ceiling's geometry. This also occurs in the original mod.

Of note, the Source 2013 build still applies extra vertical offset to the viewmodel compared to the original mod.

In addition, regular `cl_pitchdown` and `cl_pitchup` allow higher range which can make the issue more visible.

### View offset

The test map `test_viewheight.bsp` has 4 lines, from top to bottom:

1. Yellow line 1 (Normal/Standing view height)
2. Red line (Original mod duck view height)
3. Yellow line 2 (Regular HL2 duck view height)
4. Black line (Dead view height)

To test the dead view height in the original mod:

```text
kill
host_framerate 0.09
```
Wait until the fade effect goes out.

```text
host_framerate 0
```

## Additional notes

- Original mod's VEC_VIEW and VEC_DEAD_VIEWHEIGHT are identical
- Original mod's VEC_DUCK_VIEW is higher than in regular HL2

## Tests made

- Time to duck/unduck
- Duck/Stand
   - In `test_playerhull.bsp`
   - In `test_ladder.bsp` on ladder
   - Underwater  (in `1187d4.bsp`)
   - Before/After changelevel (in  `1187d3.bsp` and `1187d4.bsp`)
   - While entering/leaving vehicles (in `sdk_vehicles.bsp` with `ch_createmustang`)
   - With viewmodels
- Player view height in `test_viewheight.bsp`
  - When standing, the player's view offset is aligned with the **upper** yellow line
  - When ducked, the player's view offset is aligned with the red line
  - When dead, the player's view offset is aligned with the black line
