### PR TITLE
Fix IsGameEndAlly() condition.

### DIFF
--- a/src/game/server/ai_playerally.cpp
+++ b/src/game/server/ai_playerally.cpp
@@ -360,7 +360,7 @@ void CAI_PlayerAlly::InputMakeRegularAlly( inputdata_t &inputdata )
 
 void CAI_PlayerAlly::DisplayDeathMessage( void )
 {
-	if ( IsGameEndAlly() )
+	if ( !IsGameEndAlly() )
 		return;
 
 	CBaseEntity *pPlayer = AI_GetSinglePlayer();


### PR DESCRIPTION
This fixes game end triggered after killing a Vortigaunt. This likely occurred after 035587250595f500c216dc20da1c08c6d77f5905

Of note, `IsGameEndAlly()` returns false in for Vortigaunts in 1187.