### PR TITLE
Make Bonus maps and commentary buttons available.

### DIFF
--- a/src/game/gamepadui/gamepadui_newgame.cpp
+++ b/src/game/gamepadui/gamepadui_newgame.cpp
@@ -30,17 +30,12 @@ struct chapter_t;
 // TODO - merge these into scheme config?
 bool GameHasCommentary()
 {
-    const char *pszGameDir = CommandLine()->ParmValue( "-game", CommandLine()->ParmValue( "-defaultgamedir", "hl2" ) );
-    return !V_strcmp( pszGameDir, "episodic" ) ||
-           !V_strcmp( pszGameDir, "ep2" ) ||
-           !V_strcmp( pszGameDir, "portal" ) ||
-           !V_strcmp( pszGameDir, "lostcoast" );
+    return true;
 }
 
 bool GameHasBonusMaps()
 {
-    const char *pszGameDir = CommandLine()->ParmValue( "-game", CommandLine()->ParmValue( "-defaultgamedir", "hl2" ) );
-    return !V_strcmp( pszGameDir, "portal" );
+    return true;
 }
 
 class GamepadUINewGamePanel : public GamepadUIFrame
@@ -480,4 +475,9 @@ void GamepadUINewGamePanel::StartGame( int nChapter )
 CON_COMMAND( gamepadui_opennewgamedialog, "" )
 {
     new GamepadUINewGamePanel( GamepadUI::GetInstance().GetBasePanel(), "" );
+}
+
+CON_COMMAND(gamepadui_openbonusmapsdialog, "")
+{
+    GamepadUI::GetInstance().GetEngineClient()->ClientCmd_Unrestricted( "gamemenucommand openbonusmapsdialog\n");
 }


### PR DESCRIPTION
See #7 

This makes Bonus maps and Commentary options available in Gamepad UI.

The buttons are in the 'New Game' menu.

The Portal Gamepad UI does feature a custom Bonus Maps GUI but the current source code does not include it. For now, it displays the regular dialog. If source code can be recreated, you can change the command in `gamepadui_openbonusmapsdialog` to open a custom GamepadUI dialog.