### PR TITLE
Fix viewmodel flashlight clipping through wall.

### DIFF
--- a/src/game/client/flashlighteffect.cpp
+++ b/src/game/client/flashlighteffect.cpp
@@ -120,31 +120,24 @@ void CFlashlightEffect::TurnOff()
 	}
 }
 
-// Custom trace filter that skips the player and the view model.
-// If we don't do this, we'll end up having the light right in front of us all
-// the time.
-class CTraceFilterSkipPlayerAndViewModel : public CTraceFilter
+bool CTraceFilterSkipPlayerAndViewModel::ShouldHitEntity( IHandleEntity *pServerEntity, int contentsMask )
 {
-public:
-	virtual bool ShouldHitEntity( IHandleEntity *pServerEntity, int contentsMask )
-	{
-		// Test against the vehicle too?
-		// FLASHLIGHTFIXME: how do you know that you are actually inside of the vehicle?
-		C_BaseEntity *pEntity = EntityFromEntityHandle( pServerEntity );
-		if ( !pEntity )
-			return true;
-
-		if ( ( dynamic_cast<C_BaseViewModel *>( pEntity ) != NULL ) ||
-			 ( dynamic_cast<C_BasePlayer *>( pEntity ) != NULL ) ||
-			 pEntity->GetCollisionGroup() == COLLISION_GROUP_DEBRIS ||
-			 pEntity->GetCollisionGroup() == COLLISION_GROUP_INTERACTIVE_DEBRIS )
-		{
-			return false;
-		}
-
+	// Test against the vehicle too?
+	// FLASHLIGHTFIXME: how do you know that you are actually inside of the vehicle?
+	C_BaseEntity *pEntity = EntityFromEntityHandle( pServerEntity );
+	if ( !pEntity )
 		return true;
+
+	if ( ( dynamic_cast<C_BaseViewModel *>( pEntity ) != NULL ) ||
+			( dynamic_cast<C_BasePlayer *>( pEntity ) != NULL ) ||
+			pEntity->GetCollisionGroup() == COLLISION_GROUP_DEBRIS ||
+			pEntity->GetCollisionGroup() == COLLISION_GROUP_INTERACTIVE_DEBRIS )
+	{
+		return false;
 	}
-};
+
+	return true;
+}
 
 //-----------------------------------------------------------------------------
 // Purpose: Do the headlight

--- a/src/game/client/flashlighteffect.h
+++ b/src/game/client/flashlighteffect.h
@@ -59,6 +59,15 @@ public:
 	virtual void UpdateLight(const Vector &vecPos, const Vector &vecDir, const Vector &vecRight, const Vector &vecUp, int nDistance);
 };
 
+#include "engine/IEngineTrace.h"
 
+// Custom trace filter that skips the player and the view model.
+// If we don't do this, we'll end up having the light right in front of us all
+// the time.
+class CTraceFilterSkipPlayerAndViewModel : public CTraceFilter
+{
+public:
+	virtual bool ShouldHitEntity( IHandleEntity *pServerEntity, int contentsMask );
+};
 
 #endif // FLASHLIGHTEFFECT_H


### PR DESCRIPTION
These changes address #40.

## Context

Some of the viewmodels have wider bounds in which case the default 35 units still goes through the wall when the player is next to and facing a wall. Increasing the offset can fix it but causes more player shadows to be drawn, which isn't better. For example, standing next to and facing a wall, changing 35 to 50 will fix it for the shotgun but then using the MP5, the player's shadow is cast on the wall.

## New changes

The changes' approach consists of creating a plane, centered at and aligned with the viewmodel (plane's normal = viewmodel's forward), and calculating the intersection on the plane along the muzzle attachment's forward direction. We call the plane's intersection: *Plane point*. **Note:** finding the intersection point **does not involve tracing**.

Then, we trace from *Plane point* to the muzzle's attachment origin to see if we hit anything solid. 

<img width="261" alt="vm_general" src="https://github.com/user-attachments/assets/47b0f8a9-64ec-42d4-8781-40a957d3342c" />

(1) If we don't hit anything, we position the flashlight at the same location as in the original mod (35 units backward from the muzzle location).

<img width="202" alt="vm_case_1" src="https://github.com/user-attachments/assets/268f8c06-ddc9-4541-925e-c8b8045aaa0f" />

(2) If we hit something, we position the new flashlight origin 35 units backward from the hit location.

<img width="202" alt="vm_case_2" src="https://github.com/user-attachments/assets/eb579219-d53d-4e07-b4f1-0b06693c36c7" />

(3) If the (hit location + 35 units away) goes beyond *Plane point*, we instead choose *Plane point* to avoid casting player shadows.

<img width="202" alt="vm_case_3" src="https://github.com/user-attachments/assets/23296d5d-d2f0-4445-b5ee-8782f8c6bb51" />

In other words, we choose the shortest distance between (hit location + 35 units away) and *Plane point*.

**Note:** there's a potential edge case when the player is facing a corner (e.g. with 45 degrees between each wall and player's view) where the plane could theoretically go past the rightmost wall and fall out of map bounds. I reworked the code to see if it'd happen but it doesn't seem to so I left it as is to keep things simple.

In case any issue happens, you can switch `cl_1187_flashlight_fix` to 0 and it will use the original behavior, or revert the actual changes, notably if other issues happen and are too complex or difficult because of too many edge cases.

## New ConVars

- `cl_1187_flashlight_fix` : Set to 0/1 to disable/enable the new behavior.
- `cl_1187_flashlight_fix_debug` : Set to 1 to visualize various positions calculated in the new code.
- `cl_1187_flashlight_fix_offset` : Offset to apply to the new flashlight position away from the muzzle when it's not beyond the *Plane point*. For now, it's 35 (same as in the original mod).
- `cl_1187_flashlight_fix_debug_viewoffset` : Used to add extra forward offset to visualize both plane position and *Plane point* since they can be slightly behind the minimum view threshold.

## Tests

**Note:** No test was made in vehicles since it turns off the player's flashlight.

Done with Pistol, Colt, MP5, M4 and Shotgun :

- Standing, crouching, running (in any direction): 
  - Looking forward, up and down: 
    - Against/Not against a wall
- Jumping
- On ladder
- In water